### PR TITLE
Add Columns component

### DIFF
--- a/components/Columns.js
+++ b/components/Columns.js
@@ -1,0 +1,6 @@
+const Columns = ({ children, col }) => {
+  const COLS = { 2: "two", 3: "three", 4: "four" };
+  return <div className={`columns ${COLS[col]}`}>{children} </div>;
+};
+
+export default Columns;

--- a/index.mdx
+++ b/index.mdx
@@ -59,13 +59,13 @@ Lorem ipsum dolor sit amet, consectetur [adipisicing](#4) elit, sed do eiusmod t
 
 ## Two columns if you like
 
-<div className="columns two">
+<Columns col="2">
   
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
 
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.
-  
-</div>
+
+</Columns>
 
 ## All kinds of lists
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,11 +5,13 @@ import renderToString from "next-mdx-remote/render-to-string";
 import Head from "next/head";
 import path from "path";
 import Cover from "../components/Cover";
+import Columns from "../components/Columns";
 import Slide from "../components/Slide";
 
 const components = {
   section: Slide,
   Cover,
+  Columns,
 };
 
 export default function Presentation({ content, frontMatter }) {


### PR DESCRIPTION
`<Columns>` component allows to split content in 2, 3 or 4 column. The number of columns should be provided as "col" prop. You can use markdown inside the component:

```
<Columns col="3">

First column

Second column

Third column

</Columns>
```