### PR TITLE
Add Code component

### DIFF
--- a/components/Code.js
+++ b/components/Code.js
@@ -1,0 +1,11 @@
+const Code = ({ children, ...props }) => {
+  return (
+    <pre>
+      {children.map((node) =>
+        node?.props?.originalType === "code" ? node : <code>{node}</code>
+      )}
+    </pre>
+  );
+};
+
+export default Code;

--- a/index.mdx
+++ b/index.mdx
@@ -86,6 +86,21 @@ Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu 
 <figcaption>Marcus Tullius Cicero</figcaption>
 </figure>
 
+
+## Code samples
+
+<Code>
+  {`<!DOCTYPE html>`}
+  <code className="mark">{`  <html lang="en">`} </code>
+  <mark>{`  <head> <!--Comment-->`}</mark>
+  {`     <title>Shower</title>`}
+  {`   <meta charset="UTF-8">`}
+  {`   <link rel="stylesheet" href="screen.css">`}
+  <mark>{`<title>Shower</title>`}</mark>
+</Code>
+
+
+
 ## Code samples
 
 ```html

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,10 +5,12 @@ import renderToString from "next-mdx-remote/render-to-string";
 import Head from "next/head";
 import path from "path";
 import Cover from "../components/Cover";
+import Code from "../components/Code";
 import Slide from "../components/Slide";
 
 const components = {
   section: Slide,
+  Code,
   Cover,
 };
 
@@ -64,6 +66,7 @@ export const getStaticProps = async () => {
     components,
     mdxOptions: {
       remarkPlugins: [
+        require("remark-mark-plus"),
         [require("remark-attr"), { enableAtxHeaderInline: false }],
         require("remark-sectionize"),
       ],


### PR DESCRIPTION
The current solution is really ugly (syntax), but the only one working out of the box. As next step we could bring in custom syntax for <mark> tags and parse them from string