### PR TITLE
Fix relative asset path resolved incorrectly in next.config.js

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,8 +22,10 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: yarn install
-      - run: yarn export
+      - name: Install dependencies
+        run: yarn install
+      - name: Build and export static files
+        run: REPO_NAME=${{github.event.repository.name}} yarn export
       # for access _next directory
       - name: Add nojekyll
         run: touch ./out/.nojekyll

--- a/next.config.js
+++ b/next.config.js
@@ -3,5 +3,6 @@ const withMDX = require("@next/mdx")({
 });
 module.exports = withMDX({
   pageExtensions: ["js", "jsx", "mdx"],
-  assetPrefix: "/"
+  assetPrefix: `/${process.env.REPO_NAME}/`,
+  basePath: `/${process.env.REPO_NAME}`,
 });


### PR DESCRIPTION
Changes build config - using assetPath: "./" works for most cases, except static files referenced in vendor files, which are processed incorrectly.
Solved with requesting repo name and adding it explicitly as basePath and prefix.