### PR TITLE
Simplify theme importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,8 @@ Custom attributes are currently supported for sections, headings, links, code, s
 
 ### Adding custom styles.
 
-There are several options to pass your custom styles to the template:
-
-- Pass it through mdx template, through style field at the frontmatter (global) or jsx string - see sample [index.mdx](https://github.com/varya/shower-mdx/blob/master/index.mdx) for examples.
-
-- Use a theme. There are two themes included by default - "ribbon" and "material". The theme name needs to be specified as "theme" property in index.mdx. If you want to use custom theme, you will need to manually add name and path to [loadTheme function](https://github.com/varya/shower-mdx/blob/master/components/Head.js#L6) in Head.
+If you want to change the theme, load theme css directly at the top of [index.js](https://github.com/varya/shower-mdx/blob/master/pages/index.js). The default themes "Ribbon" and "material" are already preinstalled.
+If you want to tweak some components, you can provode css through "style" field in frontmatter or inside `<style>` tags. See [index.mdx](https://github.com/varya/shower-mdx/blob/master/index.mdx) for examples.
 
 ### Adding custom components
 

--- a/components/Head.js
+++ b/components/Head.js
@@ -3,20 +3,8 @@ import NextHead from "next/head";
 import getConfig from "next/config";
 const { publicRuntimeConfig } = getConfig();
 
-const loadTheme = (name) => {
-  switch (name) {
-    case "material":
-      import("@shower/material/styles/styles.css");
-      break;
-    case "ribbon":
-    default:
-      import("@shower/ribbon/styles/styles.css");
-  }
-};
-
-const Head = ({ title, description, style, meta, theme }) => {
+const Head = ({ title, description, style, meta }) => {
   const url = publicRuntimeConfig?.basePath;
-  loadTheme(theme);
 
   return (
     <NextHead>

--- a/index.mdx
+++ b/index.mdx
@@ -1,5 +1,4 @@
 ---
-theme: ribbon
 title: Shower Presentation Engine
 subtitle: Yours Truly, Famous Inc.
 # Incude global styles here
@@ -21,6 +20,8 @@ meta:
   website: shwr.me
   twitter: username
 ---
+
+
 
 
 ## Shower Presentation Engine 

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,6 +4,10 @@ import matter from "gray-matter";
 import renderToString from "next-mdx-remote/render-to-string";
 import * as Components from "../components";
 
+// Import your custom theme here and remove the one you don't need
+import("@shower/ribbon/styles/styles.css");
+// import("@shower/material/styles/styles.css"); // Material theme is also available by default
+
 const components = {
   section: Components.Slide,
   ...Components,


### PR DESCRIPTION
Just thought that theme importing through index.mdx frontmatter and resolving imports was far too complicated: removed all that stuff and adjusted readme accordingly.