### PR TITLE
Exclude shower.js script from bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "build": "next build",
     "start": "next start",
     "export": "next build && next export",
-    "deploy": "gh-pages -d out" 
-  },
+    "deploy": "gh-pages -d out",
+    "postinstall": "node ./scripts/copy_assets_to_public.js"
+},
   "dependencies": {
     "@mdx-js/loader": "^1.6.22",
     "@next/mdx": "^10.0.6",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,0 @@
-// This default export is required in a new `pages/_app.js` file.
-
-export default function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />;
-}
-
-if (typeof window !== "undefined") {
-  require("@shower/core/dist/shower");
-}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,6 +12,7 @@ class MyDocument extends Document {
         <Head />
         <body tabIndex="0">
           <Main />
+          <script type="text/javascript" src="shower.js"></script>
           <NextScript />
           {/* related to focus hack, to be removed */}
           <style jsx global>{`

--- a/scripts/copy_assets_to_public.js
+++ b/scripts/copy_assets_to_public.js
@@ -1,0 +1,17 @@
+// Source: https://github.com/vercel/next.js/issues/10059#issuecomment-653013076
+
+const fs = require("fs");
+const path = require("path");
+
+const output_dir = "../public/";
+const assets = [
+  /* here you can add any assets which need to be copied from node-modules into public folder before the build */
+  "../node_modules/@shower/core/dist/shower.js",
+];
+
+assets.forEach((asset_path) => {
+  const filename = path.basename(asset_path);
+  fs.createReadStream(path.resolve(__dirname, asset_path)).pipe(
+    fs.createWriteStream(path.resolve(__dirname, output_dir, filename))
+  );
+});


### PR DESCRIPTION
Move shower.js to public folder on postinstall and use as static asset from there.
Fixes #28.